### PR TITLE
Fix CYTOSCAPE-13007. Ignore attributes "NDEx UUID" and "NDEx Modification Timestamp"

### DIFF
--- a/src/main/java/org/cytoscape/io/internal/cxio/CxExporter.java
+++ b/src/main/java/org/cytoscape/io/internal/cxio/CxExporter.java
@@ -12,6 +12,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.cytoscape.application.CyApplicationManager;
 import org.cytoscape.application.TableViewRenderer;
@@ -408,7 +409,7 @@ public final class CxExporter {
 	// Network Attributes
 	private final void writeNetworkAttributes() throws IOException {
 
-		final List<AspectElement> elements = new ArrayList<>();
+		final List<AbstractAttributesAspectElement> elements = new ArrayList<>();
 		
 		// Write root table
 		if (writeSiblings) {
@@ -418,8 +419,9 @@ public final class CxExporter {
 		for (final CySubNetwork subnet : subnetworks) {
 			addNetworkAttributesHelper(CyNetwork.DEFAULT_ATTRS, subnet, elements);
 		}
+		
 
-		writeAspectElements(elements);
+		writeAspectElements((List<AspectElement>)(List<? extends AspectElement>)elements);
 	}
 	
 	private void writeTableVisualStyles() throws IOException {
@@ -711,15 +713,19 @@ public final class CxExporter {
 	
 	private final void writeHiddenAttributes() throws IOException {
 
-		final List<AspectElement> elements = new ArrayList<>();
+		final List<AbstractAttributesAspectElement> elements = new ArrayList<>();
 		if (writeSiblings) {
 			addNetworkAttributesHelper(CyNetwork.HIDDEN_ATTRS, baseNetwork, elements);
 		}
 		for (final CySubNetwork subnet : subnetworks) {
 			addNetworkAttributesHelper(CyNetwork.HIDDEN_ATTRS, subnet, elements);
 		}
+		
+		List<AspectElement> cleanedAttributes = elements.stream().filter( x -> (!x.getName().equals(CxUtil.UUID_COLUMN) 
+				                        && !x.getName().equals(CxUtil.MODIFICATION_COLUMN)))
+		.collect(Collectors.toList());
 
-		writeAspectElements(elements);
+		writeAspectElements(cleanedAttributes);
 	}
 
 	private void writeOpaqueElement(String column, String value)
@@ -869,9 +875,9 @@ public final class CxExporter {
 	 * @throws IOException 
 	 * @throws JsonParseException 
 	 */
-	@SuppressWarnings("rawtypes")
+	//@SuppressWarnings("rawtypes")
 	private void addNetworkAttributesHelper(final String namespace, final CyNetwork my_network,
-			final List<AspectElement> elements) throws JsonParseException, IOException {
+			final List<AbstractAttributesAspectElement> elements) throws JsonParseException, IOException {
 
 		final CyRow row = my_network.getRow(my_network, namespace);
 		

--- a/src/main/java/org/cytoscape/io/internal/cxio/CxUtil.java
+++ b/src/main/java/org/cytoscape/io/internal/cxio/CxUtil.java
@@ -73,6 +73,10 @@ public final class CxUtil {
 	
 	public static final String PARENT_NETWORK_COLUMN = "__parentNetwork.SUID";	
 	
+	// these 2 constants are added to fix Cytoscape-13007, filter out this 2 attributes in the hiddenAttributes aspect when importing a cx file.
+	public static final String UUID_COLUMN = "NDEx UUID";
+	public static final String MODIFICATION_COLUMN = "NDEx Modification Timestamp";
+	
 	private static String CXID_NAMESPACE = CyNetwork.HIDDEN_ATTRS;
     
     

--- a/src/main/java/org/cytoscape/io/internal/nicecy/NiceCyRootNetwork.java
+++ b/src/main/java/org/cytoscape/io/internal/nicecy/NiceCyRootNetwork.java
@@ -229,8 +229,10 @@ public class NiceCyRootNetwork extends NiceCyNetwork{
 		}
 		aspects.forEach(aspect -> {
 			HiddenAttributesElement hae = (HiddenAttributesElement) aspect;
-			NiceCyNetwork net = getNetwork(hae.getSubnetwork());
-			net.hiddenAttributes.add(hae);
+			if ( (!hae.getName().equals(CxUtil.UUID_COLUMN)) && (!hae.getName().equals(CxUtil.MODIFICATION_COLUMN))) {
+				NiceCyNetwork net = getNetwork(hae.getSubnetwork());
+				net.hiddenAttributes.add(hae);
+			}
 		});
 	}
 


### PR DESCRIPTION
Modification Timestamp" in the HiddenAttributes aspect when import and export cx1.