### PR TITLE
Resolved the issue of incorrect export values for network visual properties

### DIFF
--- a/src/main/java/org/cytoscape/io/internal/cx_writer/VisualPropertiesGatherer.java
+++ b/src/main/java/org/cytoscape/io/internal/cx_writer/VisualPropertiesGatherer.java
@@ -159,7 +159,7 @@ public final class VisualPropertiesGatherer {
         
     }
 
-    private static <T> String getSerializableVisualProperty(View<? extends CyIdentifiable> view, VisualProperty<T> vp) {
+    public static <T> String getSerializableVisualProperty(View<? extends CyIdentifiable> view, VisualProperty<T> vp) {
     	T prop = view.getVisualProperty(vp);
 		if (prop == null) {
 			return null;
@@ -657,6 +657,7 @@ public final class VisualPropertiesGatherer {
     public static void addCx2EditorPropsDependency(final String id_string,
             final VisualStyle style,
             VisualEditorProperties props) {
+    	Set<VisualPropertyDependency<?>> allDep = style.getAllVisualPropertyDependencies();
     	for (final VisualPropertyDependency<?> d : style.getAllVisualPropertyDependencies()) {
     		if (d.getIdString().equals(id_string)) {
     			props.getProperties().put(id_string, d.isDependencyEnabled());

--- a/src/main/java/org/cytoscape/io/internal/cx_writer/VisualPropertiesGatherer.java
+++ b/src/main/java/org/cytoscape/io/internal/cx_writer/VisualPropertiesGatherer.java
@@ -657,7 +657,6 @@ public final class VisualPropertiesGatherer {
     public static void addCx2EditorPropsDependency(final String id_string,
             final VisualStyle style,
             VisualEditorProperties props) {
-    	Set<VisualPropertyDependency<?>> allDep = style.getAllVisualPropertyDependencies();
     	for (final VisualPropertyDependency<?> d : style.getAllVisualPropertyDependencies()) {
     		if (d.getIdString().equals(id_string)) {
     			props.getProperties().put(id_string, d.isDependencyEnabled());

--- a/src/main/java/org/cytoscape/io/internal/cxio/CxExporter.java
+++ b/src/main/java/org/cytoscape/io/internal/cxio/CxExporter.java
@@ -1531,7 +1531,7 @@ public final class CxExporter {
         		current_visual_style, editorProps);
         VisualPropertiesGatherer.addCx2EditorPropsDependency(CxUtil.NODE_SIZE_LOCKED, current_visual_style, editorProps);
         VisualPropertiesGatherer.addCx2EditorPropsDependency(CxUtil.ARROW_COLOR_MATCHES_EDGE, current_visual_style, editorProps);
-        
+
         Map<String, Object> rawProps = editorProps.getProperties();
         boolean nodeSizeLocked = rawProps.get(CxUtil.NODE_SIZE_LOCKED).equals(Boolean.TRUE);
         boolean arrowColorMatchesEdge = rawProps.get(CxUtil.ARROW_COLOR_MATCHES_EDGE).equals(Boolean.TRUE);
@@ -1543,9 +1543,9 @@ public final class CxExporter {
         Map<String,String> cx1Style = new HashMap<>();
         for (final VisualProperty<?> visual_property : all_visual_properties) {
             if (visual_property.getTargetDataType() == CyNetwork.class) {
-            	String value_str = VisualPropertiesGatherer.getDefaultPropertyAsString(current_visual_style, visual_property);
-                if (value_str !=null && !CxioUtil.isEmpty(value_str)) {
-                	cx1Style.put(visual_property.getIdString(), value_str);
+            	String value_str = VisualPropertiesGatherer.getSerializableVisualProperty(view, visual_property);
+            	if (value_str !=null && !CxioUtil.isEmpty(value_str)) {
+            		cx1Style.put(visual_property.getIdString(), value_str);
                 }
             }
         }

--- a/src/main/java/org/cytoscape/io/internal/cxio/CxExporter.java
+++ b/src/main/java/org/cytoscape/io/internal/cxio/CxExporter.java
@@ -155,7 +155,7 @@ public final class CxExporter {
 	private CyNetworkView view;
 	
 	private TaskMonitor taskMonitor;
-
+	
 	/**
 	 * Constructor for CxExporter to write network (and it's collection) to CX. Specify 
 	 * if the exporter should attempt to use CX IDs from a previous import
@@ -1662,7 +1662,7 @@ public final class CxExporter {
     	
        	List<CxEdgeBypass> edgeBypasses = VisualPropertiesGatherer.getEdgeBypasses(
     				view, all_visual_properties, useCxId, arrowColorMatchesEdge );
-        	cx2Writer.writeFullAspectFragment(edgeBypasses);
+    	cx2Writer.writeFullAspectFragment(edgeBypasses);
     	
 		
 	}
@@ -1852,8 +1852,7 @@ public final class CxExporter {
 			return result;
 		
 	}
-	
-	
+			
 	public final void writeNetworkInCX2(Collection<String> aspects, final OutputStream out) throws IOException, NdexException {
 		
 		


### PR DESCRIPTION
Jira Ticket: [UD-2932](https://ndexbio.atlassian.net/browse/UD-2932)
Should use `getSerializableVisualProperty` instead of `getDefaultPropertyAsString` to get the network visual properties.

[UD-2932]: https://ndexbio.atlassian.net/browse/UD-2932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ